### PR TITLE
Prevent duplicate URLs to be stored

### DIFF
--- a/classes/savetabs.js
+++ b/classes/savetabs.js
@@ -113,6 +113,7 @@ class SaveTabs
 		browser.tabs
 			.query(tabQuery)
 			.then(this._collectUrls.bind(this))
+			.then(urls => urls.filter((elem, index, arr) => arr.indexOf(elem) == index)) //remove duplicate URLs
 			.then(this._storeUrls)
 			.then(() => console.log("Tabs saved"))
 			.then(() => window.close())


### PR DESCRIPTION
Duplicate URLs can be stored when multiple tabs with the same URL are open. Such tabs are now only stored once.

Closes #4.