### PR TITLE
Update content security policy

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,5 +37,5 @@
 		"browser_style": true
 	},
 
-	"content_security_policy": "default-src 'self' 'unsafe-eval'"
+	"content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';"
 }


### PR DESCRIPTION
Firefox changed the requirements for the content security policy. The result was
that the extension did not load anymore. Only an empty popup was displayed and the
option page was also empty.

New content security policy allows eval as this is required by Vue.js as used in
the extension.

Closes #22 