### PR TITLE
Fix tab handling

### DIFF
--- a/classes/defaultSettings.js
+++ b/classes/defaultSettings.js
@@ -1,0 +1,10 @@
+/**
+ * Default settings.
+ */
+export default {
+    singleTabOverwrite: true,
+    multiTabOverwrite: true,
+    skipUnknownProtocols: true,
+    tabGroups: ["Default"],
+    tabGroupsDefault: "Default"
+};

--- a/classes/savetabs.js
+++ b/classes/savetabs.js
@@ -91,8 +91,8 @@ class SaveTabs
 	deleteTabs()
 	{
 		console.log("Deleting tabs");
-		browser.storage.local
-			.remove([ SAVED_TABS_KEY ])
+			this._loadSettings()
+			.then(browser.storage.local.remove(this._computeStorageKey()))
 			.then(() => console.log("Tabs deleted"))
 			.then(() => window.close())
 			.catch(this._handleError);
@@ -274,7 +274,7 @@ class SaveTabs
 		}
 
 		return browser.storage.local.get(STORAGE_VERSION_KEY)
-			.then(data => data[STORAGE_VERSION_KEY] === CURRENT_STORAGE_VERSION ? Promise.resolve() : migrate());
+			.then(data => data[STORAGE_VERSION_KEY] === CURRENT_STORAGE_VERSION ? Promise.resolve() : migrate.call(this));
 	}
 
 	/**

--- a/classes/savetabs.js
+++ b/classes/savetabs.js
@@ -1,13 +1,7 @@
 /**
  * Default settings.
  */
- const DEFAULT_SETTINGS = {
-    singleTabOverwrite: true,
-    multiTabOverwrite: true,
-    skipUnknownProtocols: true,
-    tabGroups: ["Default"],
-    tabGroupsDefault: "Default"
-};
+import DEFAULT_SETTINGS from "./defaultSettings.js"
 
 /**
  * Key for array of saved tabs in local storage.
@@ -47,7 +41,7 @@ const NON_SAVEABLE_URLS = [
 /**
  * Class to handle saving and storing of tabs.
  */
-class SaveTabs
+export default class SaveTabs
 {
 	/**
 	 * Save all tabs in the current window.

--- a/classes/savetabs.js
+++ b/classes/savetabs.js
@@ -268,7 +268,8 @@ export default class SaveTabs
 		}
 
 		return browser.storage.local.get(STORAGE_VERSION_KEY)
-			.then(data => data[STORAGE_VERSION_KEY] === CURRENT_STORAGE_VERSION ? Promise.resolve() : migrate.call(this));
+			.then(data => data[STORAGE_VERSION_KEY] === CURRENT_STORAGE_VERSION ? Promise.resolve() : migrate.call(this))
+			.then(browser.storage.local.remove(SAVED_TABS_KEY));
 	}
 
 	/**

--- a/classes/savetabsOptions.js
+++ b/classes/savetabsOptions.js
@@ -1,19 +1,14 @@
 /**
  * Default settings.
  */
-const DEFAULT_SETTINGS = {
-    singleTabOverwrite: true,
-    multiTabOverwrite: true,
-    skipUnknownProtocols: true,
-    tabGroups: ["Default"],
-    tabGroupsDefault: "Default"
-};
+import DEFAULT_SETTINGS from "./defaultSettings.js"
+
 
 /**
  * Class to handle loading and saving options for the
  * Save Tabs extension.
  */
-class SaveTabsOptions
+export default class SaveTabsOptions
 {
 
     /**

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "__MSG_extensionName__",
-	"version": "1.2.3",
+	"version": "1.2.4",
 
 	"description": "__MSG_extensionDescription__",
 	"author": "Martin Dreier",

--- a/options/options.html
+++ b/options/options.html
@@ -5,7 +5,6 @@
         <meta charset="utf-8">
         <link rel="stylesheet" href="options.css">
         <script type="text/javascript" src="../vue/vue.min.js"></script>
-        <script type="text/javascript" src="../classes/savetabsOptions.js"></script>
     </head>
 
     <body>
@@ -50,7 +49,7 @@
             </savetabs-option-select>
         </form>
 
-        <script src="options.js"></script>
+        <script src="options.js" type="module"></script>
 
     </body>
 

--- a/options/options.js
+++ b/options/options.js
@@ -1,3 +1,4 @@
+import SaveTabsOptions from "../classes/savetabsOptions.js"
 /**
  * Vue component: Single option value for select-type value. Props:
  * - options: SaveTabsOptions instance.

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,3 +1,5 @@
+import SaveTabs from "../classes/savetabs.js"
+
 /**
  * Vue Component: List separator.
  */

--- a/popup/savetabs.html
+++ b/popup/savetabs.html
@@ -5,8 +5,7 @@
 		<link rel="stylesheet" href="popup.css">
 
 		<script src="../vue/vue.min.js" type="text/javascript"></script>
-		<script src="../classes/savetabs.js" type="text/javascript"></script>
-		<script src="./popup.js" type="text/javascript"></script>
+		<script src="./popup.js" type="module"></script>
 	</head>
 
 	<body>


### PR DESCRIPTION
This PR fixes some issues with tab handling after the introduction of the new storage format for tab groups.

* Tabs could not be deleted
* When loading tabs for the first time after installing the extension, they did not actually load
* Old storage might not be deleted

Closes #21 
Closes #24 